### PR TITLE
Adding Page Name configuration to Reports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The Embed Type determines the remaining fields to fill out.
  * Report ID: Enter the unique identifier for the report. You can find the identifier by viewing a report in the Power BI Service. The identifier is in the URL.
  * Group ID: Enter the unique identifier for the group. You can find the identifier by viewing a dashboard or report in the Power BI Service. The identifier is in the URL.
  * Dataset ID: Enter the unique identifier for the dataset. You can find the identifier by viewing a dashboard in the Power BI Service. The identifier is in the URL. This is only needed for Create Mode.
+ * Page Name: Enter the unique identifier for the Page. You can find the identifier by viewing a dashboard in the Power BI Service. The identifier is in the URL. This is is an optional parameter. If left blank, the report's default page will be shown.
 
 ### Report Visual
 

--- a/includes/class-power-bi-post-types.php
+++ b/includes/class-power-bi-post-types.php
@@ -236,7 +236,7 @@ class Power_Bi_Post_Types {
 			'default' => 'ReportSection',
 			'attributes' => array(
 				'data-conditional-id'    => $prefix . 'embed_type',
-				'data-conditional-value' => wp_json_encode( array( 'visual' ) ),
+				'data-conditional-value' => wp_json_encode( array( 'report', 'visual' ) ),
 			),
 		) );
 

--- a/includes/class-power-bi-shortcodes.php
+++ b/includes/class-power-bi-shortcodes.php
@@ -89,6 +89,7 @@ class Power_Bi_Shortcodes {
 
 		if( 'report' === $embed_type ) {
 			$report_mode = get_post_meta( $id, '_power_bi_report_mode', true );
+			$page_name 	 = get_post_meta( $id, '_power_bi_page_name', true );
 
 			if ( 'create' === $report_mode ) {
 				$embed_url = $api_url . "reportEmbed?groupId=" . $group_id;
@@ -150,6 +151,7 @@ class Power_Bi_Shortcodes {
 
 					<?php if ('report' === $embed_type) : ?>
 					id: '<?php echo $report_id; ?>',
+					pageName: '<?php echo $page_name; ?>',
 					<?php endif; ?>
 
 					<?php if ('qna' === $embed_type) : ?>


### PR DESCRIPTION
When adding a Power BI `Report` element, the `Page Name` element is not
present. If the report that is being embedded has more than one page,
that means only the report's default page will be visible.

This adds the `Page Name` setting to `Report` items, such that the user
can now configure which page from the report should be displayed.

If no value is provided, or if a non-existent identifier is given, the
report's default page is shown.