### PR TITLE
Lets users set filters for their Power BI reports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The Embed Type determines the remaining fields to fill out.
  * Group ID: Enter the unique identifier for the group. You can find the identifier by viewing a dashboard or report in the Power BI Service. The identifier is in the URL.
  * Dataset ID: Enter the unique identifier for the dataset. You can find the identifier by viewing a dashboard in the Power BI Service. The identifier is in the URL. This is only needed for Create Mode.
  * Page Name: Enter the unique identifier for the Page. You can find the identifier by viewing a dashboard in the Power BI Service. The identifier is in the URL. This is is an optional parameter. If left blank, the report's default page will be shown.
+ * Filter: An optional pre-set filter, given as a JavaScript object.
 
 ### Report Visual
 

--- a/includes/class-power-bi-post-types.php
+++ b/includes/class-power-bi-post-types.php
@@ -241,6 +241,18 @@ class Power_Bi_Post_Types {
 		) );
 
 		$metabox_details->add_field( array(
+			'name'    => 'Filter',
+			'desc'    => 'Enter a filter object. Refer to the Power BI JavaScript Wiki for more information about filters.',
+			'id'      => $prefix . 'filter',
+			'type'    => 'textarea',
+			'default' => '',
+			'attributes' => array(
+				'data-conditional-id'    => $prefix . 'embed_type',
+				'data-conditional-value' => wp_json_encode( array( 'report' ) ),
+			),
+		) );
+
+		$metabox_details->add_field( array(
 			'name'    => 'Visual Name',
 			'desc'    => 'The Visual Name can be retrieved using the GetVisuals method on the Page object.',
 			'id'      => $prefix . 'visual_name',

--- a/includes/class-power-bi-shortcodes.php
+++ b/includes/class-power-bi-shortcodes.php
@@ -43,6 +43,7 @@ class Power_Bi_Shortcodes {
 			'id' => '',
 			'width' => '',
 			'height' => '',
+ 			'filter' => '',
         ), $atts ) );
 
 		if ( empty( $id ) ) {
@@ -52,7 +53,7 @@ class Power_Bi_Shortcodes {
 		$container_width = empty( $width ) ? get_post_meta( $id, '_power_bi_width', true ) : $width;
 		$container_height = empty( $height ) ? get_post_meta( $id, '_power_bi_height', true ) : $height;
 
-		$powerbi_js = $this->powerbi_js( $id );
+		$powerbi_js = $this->powerbi_js( $id, $filter );
 
 		ob_start();
 		echo '<div id="powerbi-embedded-'. $id .'" style="height: ' . $container_height . '; width: ' . $container_width . ';"></div>';
@@ -60,7 +61,7 @@ class Power_Bi_Shortcodes {
 		return ob_get_clean();
     }
 
-	public function powerbi_js( $id ) {
+	public function powerbi_js( $id, $filter ) {
 		$power_bi_credentials = get_option('power_bi_credentials');
 
         if( isset( $power_bi_credentials['access_token'] ) ) {
@@ -90,7 +91,7 @@ class Power_Bi_Shortcodes {
 		if( 'report' === $embed_type ) {
 			$report_mode = get_post_meta( $id, '_power_bi_report_mode', true );
 			$page_name 	 = get_post_meta( $id, '_power_bi_page_name', true );
-			$filter 	 = get_post_meta( $id, '_power_bi_filter', true );
+			$filter 	 = empty( $filter ) ? get_post_meta( $id, '_power_bi_filter', true ) : $filter;
 
 			if ( 'create' === $report_mode ) {
 				$embed_url = $api_url . "reportEmbed?groupId=" . $group_id;

--- a/includes/class-power-bi-shortcodes.php
+++ b/includes/class-power-bi-shortcodes.php
@@ -90,6 +90,7 @@ class Power_Bi_Shortcodes {
 		if( 'report' === $embed_type ) {
 			$report_mode = get_post_meta( $id, '_power_bi_report_mode', true );
 			$page_name 	 = get_post_meta( $id, '_power_bi_page_name', true );
+			$filter 	 = get_post_meta( $id, '_power_bi_filter', true );
 
 			if ( 'create' === $report_mode ) {
 				$embed_url = $api_url . "reportEmbed?groupId=" . $group_id;
@@ -152,6 +153,9 @@ class Power_Bi_Shortcodes {
 					<?php if ('report' === $embed_type) : ?>
 					id: '<?php echo $report_id; ?>',
 					pageName: '<?php echo $page_name; ?>',
+					<?php if ($filter) : ?>
+					filters: [<?php echo $filter; ?>],
+					<?php endif; ?>
 					<?php endif; ?>
 
 					<?php if ('qna' === $embed_type) : ?>


### PR DESCRIPTION
This adds a new configuration option to reports: filters. It passes data in it as a JavaScript object inside the `filters` configuration option.

It also allows one to setup custom filters via the shortcode. For instance, to show a report with a filter applied, one could do:

```
[powerbi id='10' filter="{$schema:
'http://powerbi.com/product/schema#basic',
target: {table: 'Product', column: 'id'}, operator: 'In',
values: new Array('p1', 'p2', 'p3')}"]
```